### PR TITLE
fix pipeline crash when repo has uncommitted changes

### DIFF
--- a/ci/app.py
+++ b/ci/app.py
@@ -81,6 +81,7 @@ def run_pipeline(branch):
 
     # Step 1: Update repo
     git_commands = [
+         ['git', 'stash'],
         ['git', 'fetch', 'origin', branch],
         ['git', 'checkout', '-B', branch, f'origin/{branch}'],
         ['git', 'reset', '--hard', f'origin/{branch}'],


### PR DESCRIPTION
## Summary
- Add `git stash` as the first git step in `run_pipeline()` before `git checkout -B`
- Prevents pipeline from failing when the repo on EC2 has local uncommitted changes (e.g. from Docker running as root, or manual edits)

## Test plan
- [ ] Push a commit to `billing` or `weight` and confirm pipeline completes without "local changes would be overwritten" error
